### PR TITLE
Use config file instead of inline constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+heatpump2mqtt.conf

--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ The publisher prefix (default  	**home/heatpump/0** )  could defined at the top 
 - **Value**: is the raw value returned</li>
 - **Description**: is defined for each variable name in aValueDefinition</li>
 - **Details**: further details if available(IP Address, Heatpumptype, OperatingState...)</li>
+
+## Dependencies
+
+Before running the script ensure that the required python modules are installed:
+
+```bash
+pip3 install -r requirements.pip.txt
+```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This python script reads all operating values from an Luxtronics driven Heatpump (Alpha Innotec) and publish those values at an MQTT Broker.
 
-The publisher prefix (default  	**home/heatpump/0** )  could defined at the top script. The payload is an JSON Object like:
-```
+The default publisher prefix is **home/heatpump/0**. The payload is an JSON Object like:
+
+```json
 {
   "Description" : "Abtauen seit (hh:mm:ss)",
   "Name" : "Time_AbtIn",
@@ -18,6 +19,20 @@ The publisher prefix (default  	**home/heatpump/0** )  could defined at the top 
 - **Value**: is the raw value returned</li>
 - **Description**: is defined for each variable name in aValueDefinition</li>
 - **Details**: further details if available(IP Address, Heatpumptype, OperatingState...)</li>
+
+## Configuration
+
+The default configuration values are provided in `heatpump2mqtt.confspec`. To override some or all of these values provide a `heatpump2mqtt.conf` file beneath the `heatpump2mqtt.py` script, e.g.:
+
+```ini
+[Heatpump]
+host = 192.168.100.9
+
+[MQTT]
+host = 192.168.100.10
+user = my-user
+password = my-password
+```
 
 ## Dependencies
 

--- a/heatpump2mqtt.confspec
+++ b/heatpump2mqtt.confspec
@@ -1,0 +1,15 @@
+[Heatpump]
+# Heatpump Luxtronik 2.0 IP
+host = string(default='10.200.1.200')
+
+# Heatpump Luxtronik 2.0 port default 8888
+port = integer(default=8888)
+
+# MQTT Broker
+[MQTT]
+host = string(default='10.200.1.210')
+port = integer(default=1883)
+client_id = string(default='heatpump-script')
+user = string(default='openhab')
+password = string(default='ASecurePassword')
+prefix_publish_path = string(default='home/heatpump/0/')

--- a/heatpump2mqtt.py
+++ b/heatpump2mqtt.py
@@ -16,24 +16,23 @@
 # License:
 # Version: v20180315-191000
 #
+import sys
 import socket
 import struct
 import datetime
 import paho.mqtt.client as mqtt
 import json
+from configobj import ConfigObj
+from validate import Validator
 # import http.client
-##################### Constants ########################
-# Heatpump Luxtronik 2.0 IP
-sHostHeatpump = '10.200.1.200'
-# Heatpump Luxtronik 2.0 port default 8888
-iPortHeatpump = 8888
-# MQTT Broker
-sHostMQTTBroker = '10.200.1.210'
-sPortMQTTBroker = 1883
-sMQTTClientID = 'heatpump-script'
-sUserMQTTBroker = 'openhab'
-sPasswordMQTTBroker = 'ASecurePassword'
-sPrefixPublishPath='home/heatpump/0/'
+##################### Config ########################
+config=ConfigObj('heatpump2mqtt.conf', configspec='heatpump2mqtt.confspec')
+
+validator = Validator()
+if config.validate(validator) != True:
+    print( 'Config file validation failed!')
+    sys.exit(1)
+
 ########################################## Values #############################
 # Source https://service.knx-user-forum.de/?comm=download&id=19000682
 aValueDefinition=[{'UNKNOWN':None},
@@ -553,7 +552,7 @@ aData = []
 # Socket
 oSocket = socket.socket( socket.AF_INET, socket.SOCK_STREAM)
 # Connect to Heatpump
-oSocket.connect((sHostHeatpump, iPortHeatpump))
+oSocket.connect((config['Heatpump']['host'], config['Heatpump']['port']))
 
 # Send to get state
 oSocket.send( struct.pack( '!i', 3004))
@@ -607,13 +606,13 @@ rRangeDateAbsolute.extend(range(111,116,1))
 rRangeDateAbsolute.extend(range(222,227,1))
 
 # ClientID
-oMQTTClient = mqtt.Client(client_id=sMQTTClientID)
+oMQTTClient = mqtt.Client(client_id=config['MQTT']['client_id'])
 # Auth
-oMQTTClient.username_pw_set(sUserMQTTBroker, sPasswordMQTTBroker)
+oMQTTClient.username_pw_set(config['MQTT']['user'], config['MQTT']['password'])
 # Connect synchronous
-oMQTTClient.connect(sHostMQTTBroker, sPortMQTTBroker)
+oMQTTClient.connect(config['MQTT']['host'], config['MQTT']['port'])
 for iIndex in range(10,iDataFields):	
-	sPublishPath=sPrefixPublishPath+getValueDefByIndex(iIndex)['ValueName']
+	sPublishPath=config['MQTT']['prefix_publish_path']+getValueDefByIndex(iIndex)['ValueName']
 	oValue=""
 	sDetails=""
 	if iIndex in rRangeDateDiffData:

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,0 +1,3 @@
+setuptools
+wheel
+paho-mqtt

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,3 +1,4 @@
 setuptools
 wheel
 paho-mqtt
+configobj


### PR DESCRIPTION
This change eases using the script e.g. in a container without the need to modify the script file.

1. Enables to override the script default values with values provided in a config file named `heatpump2mqtt.conf` (INI format). This file has to be placed beneath the python script file. See https://configobj.readthedocs.io/en/latest/configobj.html

2. The default values are stored in `heatpump2mqtt.confspec`. These values are taken if the config file (1.) does not exist or if the config file does not provide a value for each `confspec`-variable. See https://configobj.readthedocs.io/en/latest/configobj.html#configspec

3. Documents needed python module requirements in `requirements.pip.txt` for simple usage with `pip install -r`.